### PR TITLE
Disallow passing a contextNode if target is a DOMNode

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -142,7 +142,7 @@ function xpath_get_element($target, string $query, \DOMNode $contextNode = null)
         $xpath = new \DOMXPath($target);
     } else if ($target instanceof \DOMNode) {
         if ($contextNode !== null) {
-            throw new \InvalidArgumentException('Target is an instance of DOMNode, thus $contextNode may be passed');
+            throw new \InvalidArgumentException('Target is an instance of DOMNode, thus $contextNode may not be passed');
         }
 
         $contextNode = $target;

--- a/src/functions.php
+++ b/src/functions.php
@@ -141,12 +141,16 @@ function xpath_get_element($target, string $query, \DOMNode $contextNode = null)
     } else if ($target instanceof \DOMDocument) {
         $xpath = new \DOMXPath($target);
     } else if ($target instanceof \DOMNode) {
+        if ($contextNode !== null) {
+            throw new \InvalidArgumentException('Target is an instance of DOMNode, thus $contextNode may be passed');
+        }
+
         $contextNode = $target;
         $xpath = new \DOMXPath($target->ownerDocument);
     } else {
         throw new \InvalidArgumentException('Invalid target supplied: must be a DOMXPath, DOMDocument or DOMElement');
     }
-    
+
     $results = $xpath->query($query, $contextNode);
     if ($results->length < 1) {
         throw new ElementNotFoundException('Element matching ' . $query . ' was not found');


### PR DESCRIPTION
Otherwise the context node will be silently ignored leading to undetected bugs.
