### PR TITLE
Add domdocument_load_xml

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -67,6 +67,48 @@ function domdocument_load_html(string $html, int $options = 0, string $charSet =
 }
 
 /**
+ * Loads a XML string into a DOMDocument object, with error handling and character set normalization.
+ *
+ * @param string $html
+ * @param int $options
+ * @param string $charSet
+ * @return \DOMDocument
+ * @throws LibXMLFatalErrorException
+ */
+function domdocument_load_xml(string $html, int $options = 0, string $charSet = ''): \DOMDocument
+{
+    if (!preg_match('#^\s*<\?xml#i', $html)) {
+        if ($charSet === '') {
+            $charSet = default_charset();
+        }
+
+        $html = '<?xml encoding="' . $charSet . '" ?>' . $html;
+    }
+
+    $internalErrors = null;
+
+    try {
+        $internalErrors = libxml_use_internal_errors(true);
+
+        $dom = new \DOMDocument();
+        $dom->loadXML($html, $options);
+
+        /** @var \LibXMLError $error */
+        foreach (libxml_get_errors() as $error) {
+            if ($error->level === LIBXML_ERR_FATAL) {
+                throw new LibXMLFatalErrorException($error);
+            }
+        }
+
+        return $dom;
+    } finally {
+        if ($internalErrors !== null) {
+            libxml_use_internal_errors($internalErrors);
+        }
+    }
+}
+
+/**
  * Processes a set of HTML strings into DOMDocument objects and invokes a callback for each one.
  *
  * A DOMDocument object will be passed to the first argument of the callback, and an array of LibXMLError objects
@@ -146,7 +188,7 @@ function xpath_get_element($target, string $query, \DOMNode $contextNode = null)
     } else {
         throw new \InvalidArgumentException('Invalid target supplied: must be a DOMXPath, DOMDocument or DOMElement');
     }
-    
+
     $results = $xpath->query($query, $contextNode);
     if ($results->length < 1) {
         throw new ElementNotFoundException('Element matching ' . $query . ' was not found');


### PR DESCRIPTION
I guess we could abstract most of it into a function like `withSaneLibXmlErrors` that accepts a callback and sets and restores the internal error setting, but it's fine for now.
